### PR TITLE
Fix {||} string syntax highlighting

### DIFF
--- a/.vim/syntax/ocaml.vim
+++ b/.vim/syntax/ocaml.vim
@@ -194,7 +194,7 @@ syn match    ocamlCharacter    "'\\x\x\x'"
 syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
-syn match    ocamlString       "{\(\w*\)|\(.\|\n\)*|\1}" contains=@Spell
+syn match    ocamlString       "{\(\w*\)|\(.\|\n\)\{-}|\1}" contains=@Spell
 
 syn match    ocamlFunDef       "->"
 syn match    ocamlRefAssign    ":="


### PR DESCRIPTION
`\{-}` does a non-greedy match so code like this will highlight correctly:

``` ocaml
let foo = {|a string|}
let bar = {|another string|}
```
